### PR TITLE
Fix login and some refactoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
   "scripts": {
     "format": "eslint . --ext .ts --config .eslintrc --fix",
     "compile": "tsc",
+    "oclif:readme": "oclif-dev readme",
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "eslint . --ext .ts --config .eslintrc",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   "repository": "b-eee/hexabase-cli",
   "scripts": {
     "format": "eslint . --ext .ts --config .eslintrc --fix",
+    "compile": "tsc",
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "eslint . --ext .ts --config .eslintrc",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",

--- a/src/base-with-context.ts
+++ b/src/base-with-context.ts
@@ -19,7 +19,7 @@ export default abstract class BaseWithContext extends Command {
 
   private _hexaSSE!: SSEClient
 
-  hexaconfig = new Conf()
+  hexaConfig = new Conf()
 
   context!: Context
 
@@ -35,7 +35,7 @@ export default abstract class BaseWithContext extends Command {
 
   configureHexaAPI(): void {
     let authConfig = {}
-    const token = this.hexaconfig.get(`hexabase.${this.currentContext}.token`)
+    const token = this.hexaConfig.get(`hexabase.${this.currentContext}.token`)
     if (token) {
       authConfig = {
         headers: {
@@ -56,13 +56,13 @@ export default abstract class BaseWithContext extends Command {
     if (flags.context) {
       this.currentContext = flags.context
     } else {
-      this.currentContext = this.hexaconfig.get('current-context') as string
+      this.currentContext = this.hexaConfig.get('current-context') as string
       if (!this.currentContext) {
         throw new Error(`Missing context setting: ${chalk.red('current-context')}`)
       }
     }
 
-    const context = this.hexaconfig.get(`contexts.${this.currentContext}`)
+    const context = this.hexaConfig.get(`contexts.${this.currentContext}`)
     if (!context) {
       throw new Error(`No such context: ${chalk.red(flags.context)}`)
     }

--- a/src/commands/actions/create.ts
+++ b/src/commands/actions/create.ts
@@ -75,7 +75,7 @@ export default class ActionsCreate extends BaseWithContext {
     }
 
     const url = `/api/v0/datastores/${args.datastore_id}/actions`
-    const {data: action} = await this.hexaapi.post<CreateActionResponse>(url, data)
+    const {data: action} = await this.hexaAPI.post<CreateActionResponse>(url, data)
     this.log(`Action successfully created:
 action_id: ${chalk.cyan(action.action_id)}
 display_id: ${chalk.cyan(action.display_id)}`

--- a/src/commands/actions/delete.ts
+++ b/src/commands/actions/delete.ts
@@ -46,7 +46,7 @@ export default class ActionsDelete extends BaseWithContext {
 
     if (shouldProceed) {
       const url = `/api/v0/datastores/${args.datastore_id}/actions/${args.action_id}`
-      await this.hexaapi.delete<void>(url)
+      await this.hexaAPI.delete<void>(url)
       this.log('Action successfully deleted')
     } else {
       this.log(chalk.red('Deletion  aborted'))

--- a/src/commands/actions/get.ts
+++ b/src/commands/actions/get.ts
@@ -57,10 +57,10 @@ export default class ActionsGet extends BaseWithContext {
 
     if (!args.datastore_id) {
       let url = '/api/v0/workspacecurrent'
-      const {data: currentWorkspace} = await this.hexaapi.get<GetCurrentWorkspaceResponse>(url)
+      const {data: currentWorkspace} = await this.hexaAPI.get<GetCurrentWorkspaceResponse>(url)
 
       url = `/api/v0/workspaces/${currentWorkspace.workspace_id}/applications`
-      const {data: projects} = await this.hexaapi.get<GetProjectsElemResponse[]>(url)
+      const {data: projects} = await this.hexaAPI.get<GetProjectsElemResponse[]>(url)
       this.questions[0].choices = projects.map(pj => {
         return {
           name: pj.application_id,
@@ -71,7 +71,7 @@ export default class ActionsGet extends BaseWithContext {
       const {project: project_id}: {project: string} = await prompt(this.questions[0])
 
       url = `/api/v0/applications/${project_id}/datastores`
-      const {data: datastores} =  await this.hexaapi.get<GetDatastoresElemResponse[]>(url)
+      const {data: datastores} =  await this.hexaAPI.get<GetDatastoresElemResponse[]>(url)
       this.questions[1].choices = datastores.map(ds => {
         return {
           name: ds.datastore_id,
@@ -83,7 +83,7 @@ export default class ActionsGet extends BaseWithContext {
       args.datastore_id = datastore_id
 
       url = `/api/v0/datastores/${args.datastore_id}/statuses`
-      const {data: statuses} = await this.hexaapi.get<GetStatusesElemResponse[]>(url)
+      const {data: statuses} = await this.hexaAPI.get<GetStatusesElemResponse[]>(url)
       this.questions[2].choices = statuses.map(st => {
         return {
           name: st.status_id,
@@ -99,7 +99,7 @@ export default class ActionsGet extends BaseWithContext {
     if (args.status_id) {
       url = `${url}?status_id=${args.status_id}`
     }
-    const {data: actions} = await this.hexaapi.get<GetActionsElemResponse[]>(url)
+    const {data: actions} = await this.hexaAPI.get<GetActionsElemResponse[]>(url)
 
     const columns = {
       action_id: {

--- a/src/commands/actions/scripts/download.ts
+++ b/src/commands/actions/scripts/download.ts
@@ -59,7 +59,7 @@ export default class ActionsScriptDownload extends BaseWithContext {
       // download from apicore
       cli.action.start(`Downloading ${flags.type}-script with action_id ${chalk.cyan(args.action_id)}`)
       const url = `${this.context.server}/api/v0/actions/${args.action_id}/actionscripts/download?script_type=${flags.type}`
-      const token = this.hexaconfig.get(`hexabase.${this.currentContext}.token`)
+      const token = this.hexaConfig.get(`hexabase.${this.currentContext}.token`)
       const downloadOptions = {
         mode: '666',
         filename: flags.output,

--- a/src/commands/actions/scripts/upload.ts
+++ b/src/commands/actions/scripts/upload.ts
@@ -72,7 +72,7 @@ export default class ActionsScriptsUpload extends BaseWithContext {
           ...form.getHeaders(),
         },
       }
-      await this.hexaapi.post(url, form, requestConfig)
+      await this.hexaAPI.post(url, form, requestConfig)
       cli.action.stop()
     } else {
       this.log(chalk.red('Uploading aborted'))

--- a/src/commands/actions/scripts/upload.ts
+++ b/src/commands/actions/scripts/upload.ts
@@ -65,7 +65,7 @@ export default class ActionsScriptsUpload extends BaseWithContext {
       form.append('file', fs.createReadStream(args.file))
       form.append('script_type', flags.type)
 
-      const token = this.hexaconfig.get(`hexabase.${this.currentContext}.token`)
+      const token = this.hexaConfig.get(`hexabase.${this.currentContext}.token`)
       const requestConfig = {
         headers: {
           authorization: `Bearer ${token}`,

--- a/src/commands/actions/show.ts
+++ b/src/commands/actions/show.ts
@@ -27,7 +27,7 @@ export default class ActionsShow extends BaseWithContext {
     const {args} = this.parse(ActionsShow)
 
     const url = `/api/v0/datastores/${args.datastore_id}/actions/${args.action_id}`
-    const {data: actionSettings} = await this.hexaapi.get<GetActionSettingsResponse>(url)
+    const {data: actionSettings} = await this.hexaAPI.get<GetActionSettingsResponse>(url)
 
     this.log(JSON.stringify(actionSettings, undefined, 2))
   }

--- a/src/commands/actions/update.ts
+++ b/src/commands/actions/update.ts
@@ -81,7 +81,7 @@ export default class ActionsUpdate extends BaseWithContext {
     const {args} = this.parse(ActionsUpdate)
 
     const url = `/api/v0/datastores/${args.datastore_id}/actions/${args.action_id}`
-    const {data: actionSettings} = await this.hexaapi.get<GetActionSettingsResponse>(url)
+    const {data: actionSettings} = await this.hexaAPI.get<GetActionSettingsResponse>(url)
 
     this.questions[0].initial = actionSettings.roles.filter(role => role.can_execute).map(role => role.role_id).join(', ')
     const {roles}: {roles: string[]} = await prompt(this.questions[0])
@@ -99,7 +99,7 @@ export default class ActionsUpdate extends BaseWithContext {
       roles: roles,
     }
 
-    await this.hexaapi.patch<void>(url, data)
+    await this.hexaAPI.patch<void>(url, data)
     this.log('Action successfully updated')
   }
 }

--- a/src/commands/apps/init.ts
+++ b/src/commands/apps/init.ts
@@ -89,7 +89,7 @@ export default class AppsInit extends BaseWithContext {
     }
 
     const url = '/api/v0/applications'
-    const {data: project} = await this.hexaapi.post<CreateProjectResponse>(url, hxSettings)
+    const {data: project} = await this.hexaAPI.post<CreateProjectResponse>(url, hxSettings)
     this.log(`Task successfully queued:
 project_id: ${chalk.cyan(project.project_id)}`
     )

--- a/src/commands/contexts/get.ts
+++ b/src/commands/contexts/get.ts
@@ -13,13 +13,13 @@ export default class ContextsGet extends Command {
     ...cli.table.flags(),
   }
 
-  hexaconfig = new Conf()
+  hexaConfig = new Conf()
 
   async run() {
     const {flags} = this.parse(ContextsGet)
 
-    const currentContext = this.hexaconfig.get('current-context')
-    const contexts = this.hexaconfig.get('contexts') as {[key: string]: any}
+    const currentContext = this.hexaConfig.get('current-context')
+    const contexts = this.hexaConfig.get('contexts') as {[key: string]: any}
 
     if (!contexts) {
       return this.log('No context found')

--- a/src/commands/contexts/login.ts
+++ b/src/commands/contexts/login.ts
@@ -45,13 +45,13 @@ export default class ContextsLogin extends BaseWithContext {
     try {
       let url = '/api/v0/login'
       const {data: {token}} = await this.hexaAPI.post<PostLoginResponse>(url, data)
-      this.hexaconfig.set(`hexabase.${this.currentContext}.email`, email)
-      this.hexaconfig.set(`hexabase.${this.currentContext}.token`, token)
+      this.hexaConfig.set(`hexabase.${this.currentContext}.email`, email)
+      this.hexaConfig.set(`hexabase.${this.currentContext}.token`, token)
       this.configureHexaAPI()
 
       url = '/api/v0/userinfo'
       const {data: {u_id}} = await this.hexaAPI.get<GetUserInfoResponse>(url)
-      this.hexaconfig.set(`hexabase.${this.currentContext}.user_id`, u_id)
+      this.hexaConfig.set(`hexabase.${this.currentContext}.user_id`, u_id)
 
       this.log(`Successfully logged in as: ${chalk.cyan(email)}`)
     } catch (error) {

--- a/src/commands/contexts/login.ts
+++ b/src/commands/contexts/login.ts
@@ -44,13 +44,13 @@ export default class ContextsLogin extends BaseWithContext {
 
     try {
       let url = '/api/v0/login'
-      const {data: {token}} = await this.hexaapi.post<PostLoginResponse>(url, data)
+      const {data: {token}} = await this.hexaAPI.post<PostLoginResponse>(url, data)
       this.hexaconfig.set(`hexabase.${this.currentContext}.email`, email)
       this.hexaconfig.set(`hexabase.${this.currentContext}.token`, token)
       this.configureHexaAPI()
 
       url = '/api/v0/userinfo'
-      const {data: {u_id}} = await this.hexaapi.get<GetUserInfoResponse>(url)
+      const {data: {u_id}} = await this.hexaAPI.get<GetUserInfoResponse>(url)
       this.hexaconfig.set(`hexabase.${this.currentContext}.user_id`, u_id)
 
       this.log(`Successfully logged in as: ${chalk.cyan(email)}`)

--- a/src/commands/contexts/login.ts
+++ b/src/commands/contexts/login.ts
@@ -47,6 +47,7 @@ export default class ContextsLogin extends BaseWithContext {
       const {data: {token}} = await this.hexaapi.post<PostLoginResponse>(url, data)
       this.hexaconfig.set(`hexabase.${this.currentContext}.email`, email)
       this.hexaconfig.set(`hexabase.${this.currentContext}.token`, token)
+      this.configureHexaAPI()
 
       url = '/api/v0/userinfo'
       const {data: {u_id}} = await this.hexaapi.get<GetUserInfoResponse>(url)

--- a/src/commands/contexts/set.ts
+++ b/src/commands/contexts/set.ts
@@ -19,7 +19,7 @@ export default class ContextsSet extends Command {
     },
   ]
 
-  hexaconfig = new Conf()
+  hexaConfig = new Conf()
 
   async run() {
     const {args, flags} = this.parse(ContextsSet)
@@ -27,10 +27,10 @@ export default class ContextsSet extends Command {
       throw new Error('At least one flag needed')
     }
     Object.entries(flags).forEach(entry => {
-      this.hexaconfig.set(`contexts.${args.context}.${entry[0]}`, entry[1])
+      this.hexaConfig.set(`contexts.${args.context}.${entry[0]}`, entry[1])
     })
-    if (!this.hexaconfig.get('current-context')) {
-      this.hexaconfig.set('current-context', args.context)
+    if (!this.hexaConfig.get('current-context')) {
+      this.hexaConfig.set('current-context', args.context)
       this.log(`Current-context set to: ${chalk.cyan(args.context)}`)
     }
   }

--- a/src/commands/contexts/use.ts
+++ b/src/commands/contexts/use.ts
@@ -28,12 +28,12 @@ export default class ContextsUse extends Command {
     },
   ]
 
-  hexaconfig = new Conf()
+  hexaConfig = new Conf()
 
   async run() {
     const {args} = this.parse(ContextsUse)
 
-    const contexts = this.hexaconfig.get('contexts')
+    const contexts = this.hexaConfig.get('contexts')
     if (!contexts) {
       return this.log('No context found')
     }
@@ -48,7 +48,7 @@ export default class ContextsUse extends Command {
       throw new Error('No such context')
     }
 
-    this.hexaconfig.set('current-context', args.context)
+    this.hexaConfig.set('current-context', args.context)
     this.log(`Current-context successfully set to: ${chalk.cyan(args.context)}`)
   }
 }

--- a/src/commands/datastores/get.ts
+++ b/src/commands/datastores/get.ts
@@ -38,10 +38,10 @@ export default class DatastoresGet extends BaseWithContext {
 
     if (!args.project_id) {
       let url = '/api/v0/workspacecurrent'
-      const {data: currentWorkspace} = await this.hexaapi.get<GetCurrentWorkspaceResponse>(url)
+      const {data: currentWorkspace} = await this.hexaAPI.get<GetCurrentWorkspaceResponse>(url)
 
       url = `/api/v0/workspaces/${currentWorkspace.workspace_id}/applications`
-      const {data: projects} = await this.hexaapi.get<GetProjectsElemResponse[]>(url)
+      const {data: projects} = await this.hexaAPI.get<GetProjectsElemResponse[]>(url)
       this.questions[0].choices = projects.map(pj => {
         return {
           name: pj.application_id,
@@ -54,7 +54,7 @@ export default class DatastoresGet extends BaseWithContext {
     }
 
     const url = `/api/v0/applications/${args.project_id}/datastores`
-    const {data: datastores} =  await this.hexaapi.get<GetDatastoresElemResponse[]>(url)
+    const {data: datastores} =  await this.hexaAPI.get<GetDatastoresElemResponse[]>(url)
 
     const columns = {
       datastore_id: {

--- a/src/commands/fields/create.ts
+++ b/src/commands/fields/create.ts
@@ -86,7 +86,7 @@ export default class FieldsCreate extends BaseWithContext {
     }
 
     const url = `/api/v0/datastores/${args.datastore_id}/fields`
-    const {data: field} = await this.hexaapi.post<CreateFieldResponse>(url, data)
+    const {data: field} = await this.hexaAPI.post<CreateFieldResponse>(url, data)
     this.log(`Field successfully created:
 field_id: ${chalk.cyan(field.field_id)}
 display_id: ${chalk.cyan(field.display_id)}`

--- a/src/commands/fields/delete.ts
+++ b/src/commands/fields/delete.ts
@@ -46,7 +46,7 @@ export default class FieldsDelete extends BaseWithContext {
 
     if (shouldProceed) {
       const url = `/api/v0/datastores/${args.datastore_id}/fields/${args.field_id}`
-      await this.hexaapi.delete<void>(url)
+      await this.hexaAPI.delete<void>(url)
       this.log('Field successfully deleted')
     } else {
       this.log(chalk.red('Deletion  aborted'))

--- a/src/commands/fields/get.ts
+++ b/src/commands/fields/get.ts
@@ -46,10 +46,10 @@ export default class FieldsGet extends BaseWithContext {
 
     if (!args.datastore_id) {
       let url = '/api/v0/workspacecurrent'
-      const {data: currentWorkspace} = await this.hexaapi.get<GetCurrentWorkspaceResponse>(url)
+      const {data: currentWorkspace} = await this.hexaAPI.get<GetCurrentWorkspaceResponse>(url)
 
       url = `/api/v0/workspaces/${currentWorkspace.workspace_id}/applications`
-      const {data: projects} = await this.hexaapi.get<GetProjectsElemResponse[]>(url)
+      const {data: projects} = await this.hexaAPI.get<GetProjectsElemResponse[]>(url)
       this.questions[0].choices = projects.map(pj => {
         return {
           name: pj.application_id,
@@ -60,7 +60,7 @@ export default class FieldsGet extends BaseWithContext {
       const {project: project_id}: {project: string} = await prompt(this.questions[0])
 
       url = `/api/v0/applications/${project_id}/datastores`
-      const {data: datastores} =  await this.hexaapi.get<GetDatastoresElemResponse[]>(url)
+      const {data: datastores} =  await this.hexaAPI.get<GetDatastoresElemResponse[]>(url)
       this.questions[1].choices = datastores.map(ds => {
         return {
           name: ds.datastore_id,
@@ -73,7 +73,7 @@ export default class FieldsGet extends BaseWithContext {
     }
 
     const url = `/api/v0/datastores/${args.datastore_id}/fields`
-    const {data: fieldsResponse} = await this.hexaapi.get<GetFieldsResponse>(url)
+    const {data: fieldsResponse} = await this.hexaAPI.get<GetFieldsResponse>(url)
     let fields: GetFieldsElemResponse[] = []
     if (fieldsResponse.fields) {
       // fieldsResponse is returned as an object -> convert to sorted array

--- a/src/commands/fields/show.ts
+++ b/src/commands/fields/show.ts
@@ -27,7 +27,7 @@ export default class FieldsShow extends BaseWithContext {
     const {args} = this.parse(FieldsShow)
 
     const url = `/api/v0/datastores/${args.datastore_id}/fields/${args.field_id}`
-    const {data: fieldSettings} = await this.hexaapi.get<GetFieldSettingsResponse>(url)
+    const {data: fieldSettings} = await this.hexaAPI.get<GetFieldSettingsResponse>(url)
 
     this.log(JSON.stringify(fieldSettings, undefined, 2))
   }

--- a/src/commands/fields/update.ts
+++ b/src/commands/fields/update.ts
@@ -81,7 +81,7 @@ export default class FieldsUpdate extends BaseWithContext {
     const {args} = this.parse(FieldsUpdate)
 
     const url = `/api/v0/datastores/${args.datastore_id}/fields/${args.field_id}`
-    const {data: fieldSettings} = await this.hexaapi.get<GetFieldSettingsResponse>(url)
+    const {data: fieldSettings} = await this.hexaAPI.get<GetFieldSettingsResponse>(url)
 
     this.questions[0].initial = fieldSettings.roles.filter(role => role.can_use).map(role => role.role_id).join(', ')
     const {roles}: {roles: string[]} = await prompt(this.questions[0])
@@ -100,7 +100,7 @@ export default class FieldsUpdate extends BaseWithContext {
       roles: roles,
     }
 
-    await this.hexaapi.patch<void>(url, data)
+    await this.hexaAPI.patch<void>(url, data)
     this.log('Field successfully updated')
   }
 }

--- a/src/commands/logs/actionscript.ts
+++ b/src/commands/logs/actionscript.ts
@@ -22,17 +22,17 @@ export default class LogsActionscript extends BaseWithContext {
     const {args} = this.parse(LogsActionscript)
     const {channel} = args
 
-    this.hexasse.connect(`/sse?channel=${channel}`)
+    this.hexaSSE.connect(`/sse?channel=${channel}`)
 
-    if (!this.hexasse.source) {
+    if (!this.hexaSSE.source) {
       throw new Error('Could not establish connection')
     }
 
-    this.log(`Listening for logs on ${chalk.cyan(this.hexasse.baseUrl)}...`)
-    this.hexasse.source.addEventListener('log_actionscript', (event: Event) => {
+    this.log(`Listening for logs on ${chalk.cyan(this.hexaSSE.baseUrl)}...`)
+    this.hexaSSE.source.addEventListener('log_actionscript', (event: Event) => {
       this.log(JSON.parse((event as MessageEvent).data).message)
     })
-    this.hexasse.source.addEventListener('error', (error: Event) => {
+    this.hexaSSE.source.addEventListener('error', (error: Event) => {
       throw error
     })
   }

--- a/src/commands/projects/backup.ts
+++ b/src/commands/projects/backup.ts
@@ -52,7 +52,7 @@ export default class ProjectsBackup extends BaseWithContext {
     try {
       if (!args.template_id) {
         const url = '/api/v0/templates'
-        const {data: templates} = await this.hexaapi.get<GetTemplatesCategoryResponse>(url)
+        const {data: templates} = await this.hexaAPI.get<GetTemplatesCategoryResponse>(url)
 
         if (templates.categories.length === 0) {
           return this.log(chalk.red('No template found'))

--- a/src/commands/projects/backup.ts
+++ b/src/commands/projects/backup.ts
@@ -83,7 +83,7 @@ export default class ProjectsBackup extends BaseWithContext {
       // download from apicore
       cli.action.start(`Downloading template with tp_id ${chalk.cyan(args.template_id)}`)
       const url = `${this.context.server}/api/v0/templates/${args.template_id}/download`
-      const token = this.hexaconfig.get(`hexabase.${this.currentContext}.token`)
+      const token = this.hexaConfig.get(`hexabase.${this.currentContext}.token`)
       const downloadOptions = {
         mode: '666',
         filename: flags.output,

--- a/src/commands/projects/create.ts
+++ b/src/commands/projects/create.ts
@@ -42,7 +42,7 @@ export default class ProjectsCreate extends BaseWithContext {
     this.parse(ProjectsCreate)
 
     let url = '/api/v0/templates'
-    const {data: templates} = await this.hexaapi.get<GetTemplatesCategoryResponse>(url)
+    const {data: templates} = await this.hexaAPI.get<GetTemplatesCategoryResponse>(url)
     const initalChoice = [{
       name: 'none',
       message: 'none',
@@ -71,7 +71,7 @@ export default class ProjectsCreate extends BaseWithContext {
       data.tp_id = template_id
     }
     url = '/api/v0/applications'
-    const {data: project} = await this.hexaapi.post<CreateProjectResponse>(url, data)
+    const {data: project} = await this.hexaAPI.post<CreateProjectResponse>(url, data)
     this.log(`Task successfully queued. project_id set to: ${chalk.cyan(project.project_id)}`)
   }
 }

--- a/src/commands/projects/get.ts
+++ b/src/commands/projects/get.ts
@@ -19,10 +19,10 @@ export default class ProjectsGet extends BaseWithContext {
     const {flags} = this.parse(ProjectsGet)
 
     let url = '/api/v0/workspacecurrent'
-    const {data: currentWorkspace} = await this.hexaapi.get<GetCurrentWorkspaceResponse>(url)
+    const {data: currentWorkspace} = await this.hexaAPI.get<GetCurrentWorkspaceResponse>(url)
 
     url = `/api/v0/workspaces/${currentWorkspace.workspace_id}/applications`
-    const {data: projects} = await this.hexaapi.get<GetProjectsElemResponse[]>(url)
+    const {data: projects} = await this.hexaAPI.get<GetProjectsElemResponse[]>(url)
 
     const columns = {
       application_id: {

--- a/src/commands/projects/restore.ts
+++ b/src/commands/projects/restore.ts
@@ -56,7 +56,7 @@ export default class ProjectsRestore extends BaseWithContext {
       }
 
       const url = '/api/v0/workspaces'
-      const {data: workspaceResponse} = await this.hexaapi.get<GetWorkspacesResponse>(url)
+      const {data: workspaceResponse} = await this.hexaAPI.get<GetWorkspacesResponse>(url)
       const currentWorkspace = workspaceResponse.workspaces.find((ws): boolean => {
         return ws.workspace_id === workspaceResponse.current_workspace_id
       })
@@ -85,7 +85,7 @@ export default class ProjectsRestore extends BaseWithContext {
             ...form.getHeaders(),
           },
         }
-        await this.hexaapi.post(url, form, requestConfig)
+        await this.hexaAPI.post(url, form, requestConfig)
         cli.action.stop()
       } else {
         this.log(chalk.red('Restoring aborted'))

--- a/src/commands/projects/restore.ts
+++ b/src/commands/projects/restore.ts
@@ -78,7 +78,7 @@ export default class ProjectsRestore extends BaseWithContext {
         form.append('file', fs.createReadStream(args.file))
         form.append('name', flags.name)
 
-        const token = this.hexaconfig.get(`hexabase.${this.currentContext}.token`)
+        const token = this.hexaConfig.get(`hexabase.${this.currentContext}.token`)
         const requestConfig = {
           headers: {
             authorization: `Bearer ${token}`,

--- a/src/commands/projects/roles/get.ts
+++ b/src/commands/projects/roles/get.ts
@@ -24,7 +24,7 @@ export default class ProjectsRolesGet extends BaseWithContext {
     const {args, flags} = this.parse(ProjectsRolesGet)
 
     const url = `/api/v0/applications/${args.project_id}/roles`
-    const {data: roles} = await this.hexaapi.get<GetProjectRolesElemResponse[]>(url)
+    const {data: roles} = await this.hexaAPI.get<GetProjectRolesElemResponse[]>(url)
 
     const columns = {
       role_id: {

--- a/src/commands/projects/save.ts
+++ b/src/commands/projects/save.ts
@@ -68,10 +68,10 @@ export default class ProjectsSave extends BaseWithContext {
 
     if (!args.project_id) {
       let url = '/api/v0/workspacecurrent'
-      const {data: currentWorkspace} = await this.hexaapi.get<GetCurrentWorkspaceResponse>(url)
+      const {data: currentWorkspace} = await this.hexaAPI.get<GetCurrentWorkspaceResponse>(url)
 
       url = `/api/v0/workspaces/${currentWorkspace.workspace_id}/applications`
-      const {data: projects} = await this.hexaapi.get<GetProjectsElemResponse[]>(url)
+      const {data: projects} = await this.hexaAPI.get<GetProjectsElemResponse[]>(url)
 
       if (projects.length === 0) {
         return this.log(chalk.red('No project found'))
@@ -105,13 +105,13 @@ export default class ProjectsSave extends BaseWithContext {
       ...templateForm,
     }
     let url = '/api/v0/templates'
-    const {data: template} = await this.hexaapi.post<CreateNewProjectTemplateResponse>(url, newProjectReq)
+    const {data: template} = await this.hexaAPI.post<CreateNewProjectTemplateResponse>(url, newProjectReq)
 
     cli.action.start('Task successfully queued')
 
     const poller = new Poller(-1) // wait until we get a response
     url = `/api/v0/tasks?category=SAVETEMPLATE&all=true&stream_id=${template.stream_id}`
-    const fn = () => this.hexaapi.get<TasksObject>(url)
+    const fn = () => this.hexaAPI.get<TasksObject>(url)
     const retryCondition = ({data}: {data: TasksObject}) => {
       const queueTask = data[Object.keys(data)[0]]
       // StatusQueued: 0, StatusProgress: 1, StatusDone: 2, StatusError: 3, StatusDead: 4

--- a/src/commands/projects/save.ts
+++ b/src/commands/projects/save.ts
@@ -138,7 +138,7 @@ export default class ProjectsSave extends BaseWithContext {
     if (flags.download) {
       cli.action.start(`Downloading template with tp_id ${chalk.cyan(template.tp_id)}`)
       url = `${this.context.server}/api/v0/templates/${template.tp_id}/download`
-      const token = this.hexaconfig.get(`hexabase.${this.currentContext}.token`)
+      const token = this.hexaConfig.get(`hexabase.${this.currentContext}.token`)
       const downloadOptions = {
         mode: '666',
         filename: flags.download,

--- a/src/commands/statuses/get.ts
+++ b/src/commands/statuses/get.ts
@@ -46,10 +46,10 @@ export default class StatusesGet extends BaseWithContext {
 
     if (!args.datastore_id) {
       let url = '/api/v0/workspacecurrent'
-      const {data: currentWorkspace} = await this.hexaapi.get<GetCurrentWorkspaceResponse>(url)
+      const {data: currentWorkspace} = await this.hexaAPI.get<GetCurrentWorkspaceResponse>(url)
 
       url = `/api/v0/workspaces/${currentWorkspace.workspace_id}/applications`
-      const {data: projects} = await this.hexaapi.get<GetProjectsElemResponse[]>(url)
+      const {data: projects} = await this.hexaAPI.get<GetProjectsElemResponse[]>(url)
       this.questions[0].choices = projects.map(pj => {
         return {
           name: pj.application_id,
@@ -60,7 +60,7 @@ export default class StatusesGet extends BaseWithContext {
       const {project: project_id}: {project: string} = await prompt(this.questions[0])
 
       url = `/api/v0/applications/${project_id}/datastores`
-      const {data: datastores} =  await this.hexaapi.get<GetDatastoresElemResponse[]>(url)
+      const {data: datastores} =  await this.hexaAPI.get<GetDatastoresElemResponse[]>(url)
       this.questions[1].choices = datastores.map(ds => {
         return {
           name: ds.datastore_id,
@@ -73,7 +73,7 @@ export default class StatusesGet extends BaseWithContext {
     }
 
     const url = `/api/v0/datastores/${args.datastore_id}/statuses`
-    const {data: statuses} = await this.hexaapi.get<GetStatusesElemResponse[]>(url)
+    const {data: statuses} = await this.hexaAPI.get<GetStatusesElemResponse[]>(url)
 
     const columns = {
       status_id: {

--- a/src/commands/workspaces/get.ts
+++ b/src/commands/workspaces/get.ts
@@ -19,7 +19,7 @@ export default class WorkspacesGet extends BaseWithContext {
     const {flags} = this.parse(WorkspacesGet)
 
     const url = '/api/v0/workspaces'
-    const {data: workspaceResponse} = await this.hexaapi.get<GetWorkspacesResponse>(url)
+    const {data: workspaceResponse} = await this.hexaAPI.get<GetWorkspacesResponse>(url)
     const currentWorkspace = workspaceResponse.workspaces.find((ws): boolean => {
       return ws.workspace_id === workspaceResponse.current_workspace_id
     })

--- a/src/commands/workspaces/use.ts
+++ b/src/commands/workspaces/use.ts
@@ -34,7 +34,7 @@ export default class WorkspacesUse extends BaseWithContext {
     const {args} = this.parse(WorkspacesUse)
 
     let url = '/api/v0/workspaces'
-    const {data: workspaceResponse} = await this.hexaapi.get<GetWorkspacesResponse>(url)
+    const {data: workspaceResponse} = await this.hexaAPI.get<GetWorkspacesResponse>(url)
     if (!args.workspace_id) {
       this.questions[0].choices = workspaceResponse.workspaces.map(ws => {
         return {
@@ -48,7 +48,7 @@ export default class WorkspacesUse extends BaseWithContext {
     }
 
     url = `/api/v0/workspaces/${args.workspace_id}/select`
-    await this.hexaapi.post<void>(url)
+    await this.hexaAPI.post<void>(url)
     const currentWorkspace = workspaceResponse.workspaces.find((ws): boolean => {
       return ws.workspace_id === args.workspace_id
     })

--- a/src/helpers/poller.ts
+++ b/src/helpers/poller.ts
@@ -1,10 +1,6 @@
-/* eslint-disable no-await-in-loop */
-function wait(ms: number) {
-  return new Promise(resolve => {
-    setTimeout(resolve, ms)
-  })
-}
+import {wait} from './wait'
 
+/* eslint-disable no-await-in-loop */
 export class Poller {
   private _attempts: number
 

--- a/src/helpers/wait.ts
+++ b/src/helpers/wait.ts
@@ -1,0 +1,5 @@
+export function wait(ms: number) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms)
+  })
+}


### PR DESCRIPTION
- fix login error:
  - error: still getting 401 after login (401 is from `/userinfo` endpoint)
  - login gets token from backend, but authConfig in hexaAPI was not updated
  - added `configureHexaAPI` to reconfigure hexaAPI ([line](https://github.com/b-eee/hexabase-cli/pull/17/files#diff-bd640cea3a841be2e9e4c691e5b3146823b474197b97988b6e4b648acc1f3cd0R36)) and call it in `hx login` command ([line](https://github.com/b-eee/hexabase-cli/pull/17/files#diff-c43019a98c6d632910700770a880897d3f6592f596f4fb88219ce9a28825f2c3R50))
- refactoring:
  - fix variable naming: FROM hexaapi, hexasse, hexaconfig TO hexaAPI, hexaSSE, hexaConfig (camelCase)
  - add npm scripts: `compile` and `oclif:readme`
  - move `wait` helper function to separate file